### PR TITLE
Extend edilen paketlerle metod ismi uyumu için yapılan çalışmaları barındırır.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,64 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.7] - 2025-03-20
+
+### 🐛 Bug Fixes
+
+- Ana projeden deadpool-postrges cratesi export edildi.
+
+### 🚜 Refactor
+
+- Bu commit, parsql-sqlite paketinde metod isimlerini diğer parsql paketleriyle tutarlı hale getirmek amacıyla aşağıdaki değişiklikleri içermektedir:Yapılan Değişiklikler
+
+* Kod Değişiklikleri
+
+- CrudOps trait'inde get ve get_all metodları fetch ve fetch_all olarak yeniden adlandırıldı
+- Eski metodlar geriye dönük uyumluluk için #[deprecated] olarak işaretlendi
+- transactional_ops.rs dosyasında tx_get ve tx_get_all fonksiyonları tx_fetch ve tx_fetch_all olarak yeniden adlandırıldı
+- lib.rs dosyasında yeni metod adları dışa aktarıldı
+
+* Belgelendirme Değişiklikleri
+
+- README.md ve README.en.md dosyalarındaki tüm örnekler ve açıklamalar güncellendi
+- Metod isimlerinin değiştirilmesiyle ilgili referanslar güncellendi
+- Örneklerde get yerine fetch kullanımı gösterildi
+
+* Diğer İyileştirmeler
+
+- Metod belgelerinde (doc comments) güncelleme ve iyileştirmeler yapıldı
+- Belgelendirmelerde bölüm isimleri ve başlıklar tutarlı hale getirildi
+- Türkçe ve İngilizce belgeler senkronize edildi
+
+Bu değişiklikler, parsql ekosistemindeki tüm paketlerin tutarlı bir isimlendirme düzenine sahip olmasını sağlamaktadır. Geriye dönük uyumluluk korunduğu için mevcut kodların çalışmaya devam etmesi garanti edilmiştir.
+
+### 📚 Documentation
+
+- Versiyon ile ilgili dökümantasyon güncellemesi.
+
+### ⚙️ Miscellaneous Tasks
+
+- *(release)* Bugfix için versiyon yükseltme.
+- *(release)* Deadpool-postgres için export durumundan kaynaklı versiyon yükseltme.
+- *(release)* Versiyon problemleri...
+
+## [0.3.4] - 2025-03-14
+
+### 🐛 Bug Fixes
+
+- Parsql-tokio-postgres ve parsql-deadpool-postgres crate'lerindeki extension metodların aseknron desteği güncellendi.
+
+### ⚙️ Miscellaneous Tasks
+
+- *(release)* V0.3.3 için hazırlıklar.
+
 ## [0.3.3] - 2025-03-14
 
 ### 🚀 Features
 
+- Artık  işlemleri, ilgili cratelerin veritabanı istemci nesneleri üzerinde bir  metod gibi çağırılabilecek.
+- Bağlantı havuzu yapısına daha etkin destek için,  cratesi oluşturuldu. Transactional işlemler içinde daha efektif destekler eklendi.
+- Derive makrosuna sayfalama desteği eklemek için  ve  öznitelikleri eklendi.
 - Artık  işlemleri, ilgili cratelerin veritabanı istemci nesneleri üzerinde bir extension metod gibi çağırılabilecek. Ek olarak crate'lere transactional işlem desteği eklendi.
 - Bağlantı havuzu yapısına daha etkin destek için 'parsql-deadpool-posgres' cratesi oluşturuldu. crud işlemleri, 'Pool' struct'ı için extension olarak genişletildi. Transactional işlemler içinde daha efektif destekler eklendi.
 - 'Queryable' derive makrosuna sayfalama desteği eklemek için 'limit' ve 'offset' öznitelikleri eklendi.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.7] - 2025-03-20
+## [0.3.7] - 2025-03-22
 
 ### 🐛 Bug Fixes
 
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🚜 Refactor
 
-- Bu commit, parsql-sqlite paketinde metod isimlerini diğer parsql paketleriyle tutarlı hale getirmek amacıyla aşağıdaki değişiklikleri içermektedir:Yapılan Değişiklikler
+- Extend edilen paketlerle metod ismi uyumu için yapılan çalışmaları barındırır.
 
 * Kod Değişiklikleri
 
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 - Belgelendirmelerde bölüm isimleri ve başlıklar tutarlı hale getirildi
 - Türkçe ve İngilizce belgeler senkronize edildi
 
-Bu değişiklikler, parsql ekosistemindeki tüm paketlerin tutarlı bir isimlendirme düzenine sahip olmasını sağlamaktadır. Geriye dönük uyumluluk korunduğu için mevcut kodların çalışmaya devam etmesi garanti edilmiştir.
+Geriye dönük uyumluluk korunduğu için mevcut kodların çalışmaya devam etmesi garanti edilmiştir.
 
 ### 📚 Documentation
 
@@ -43,6 +43,7 @@ Bu değişiklikler, parsql ekosistemindeki tüm paketlerin tutarlı bir isimlend
 - *(release)* Bugfix için versiyon yükseltme.
 - *(release)* Deadpool-postgres için export durumundan kaynaklı versiyon yükseltme.
 - *(release)* Versiyon problemleri...
+- *(release)* Yayınlama öncesi versiyon için dökümantasyon düzenleme çalışmaları.
 
 ## [0.3.4] - 2025-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Bu değişiklikler, parsql ekosistemindeki tüm paketlerin tutarlı bir isimlend
 ### 📚 Documentation
 
 - Versiyon ile ilgili dökümantasyon güncellemesi.
+- V0.3.7 için CHANGELOG.md düzenlemesi.
 
 ### ⚙️ Miscellaneous Tasks
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ edition = "2021"
 categories = ["database", "asynchronous"]
 keywords = ["database", "async", "postgres", "sqlite"]
 repository = "https://github.com/yazdostum-nettr/parsql"
-version = "0.3.6"
+version = "0.3.7"
 license = "MIT OR Apache-2.0"
 
 [package]
 name = "parsql"
-version = "0.3.6"
+version = "0.3.7"
 description = "Deneyimsel bir sql yardımcı küfesidir. UYARI: bu bir ORM aracı değildir. Amaç sql yazımı ve kullanımında basit cümlecikler için kolaylık sağlamaktır."
 license.workspace = true
 edition.workspace = true
@@ -47,18 +47,18 @@ deadpool-postgres = [
 ]
 
 [workspace.dependencies]
-parsql-macros = { path = "parsql-macros", version = "0.3.6" }
-parsql-sqlite = { path = "parsql-sqlite", version = "0.3.6" }
-parsql-postgres = { path = "parsql-postgres", version = "0.3.6" }
-parsql-tokio-postgres = { path = "parsql-tokio-postgres", version = "0.3.6" }
-parsql-deadpool-postgres = { path = "parsql-deadpool-postgres", version = "0.3.6" }
+parsql-macros = { path = "parsql-macros", version = "0.3.7" }
+parsql-sqlite = { path = "parsql-sqlite", version = "0.3.7" }
+parsql-postgres = { path = "parsql-postgres", version = "0.3.7" }
+parsql-tokio-postgres = { path = "parsql-tokio-postgres", version = "0.3.7" }
+parsql-deadpool-postgres = { path = "parsql-deadpool-postgres", version = "0.3.7" }
 
 [dependencies]
-parsql-macros = { workspace = true, version = "0.3.6" }
-parsql-sqlite = { workspace = true, version = "0.3.6", optional = true }
-parsql-postgres = { workspace = true, version = "0.3.6", optional = true }
-parsql-tokio-postgres = { workspace = true, version = "0.3.6", optional = true }
-parsql-deadpool-postgres = { workspace = true, version = "0.3.6", optional = true }
+parsql-macros = { workspace = true, version = "0.3.7" }
+parsql-sqlite = { workspace = true, version = "0.3.7", optional = true }
+parsql-postgres = { workspace = true, version = "0.3.7", optional = true }
+parsql-tokio-postgres = { workspace = true, version = "0.3.7", optional = true }
+parsql-deadpool-postgres = { workspace = true, version = "0.3.7", optional = true }
 
 [workspace.lints.clippy]
 cast_possible_truncation = 'deny'

--- a/README.en.md
+++ b/README.en.md
@@ -48,27 +48,32 @@ Parsql supports the following database systems:
 
 ## Installation
 
-Add to your Cargo.toml file as follows:
+Add the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-parsql = "0.3.6"
+parsql = { version = "0.3.7", features = ["sqlite"] }
 ```
 
-and select the feature you need:
+or for PostgreSQL:
 
 ```toml
-# For SQLite
-parsql = { version = "0.3.6", features = ["sqlite"] }
+[dependencies]
+parsql = { version = "0.3.7", features = ["postgres"] }
+```
 
-# For PostgreSQL
-parsql = { version = "0.3.6", features = ["postgres"] }
+or for Tokio PostgreSQL:
 
-# For Tokio PostgreSQL
-parsql = { version = "0.3.6", features = ["tokio-postgres"] }
+```toml
+[dependencies]
+parsql = { version = "0.3.7", features = ["tokio-postgres"] }
+```
 
-# For Deadpool PostgreSQL
-parsql = { version = "0.3.6", features = ["deadpool-postgres"] }
+or for Deadpool PostgreSQL:
+
+```toml
+[dependencies]
+parsql = { version = "0.3.7", features = ["deadpool-postgres"] }
 ```
 
 ## Core Features

--- a/README.md
+++ b/README.md
@@ -48,27 +48,32 @@ Parsql aşağıdaki veritabanı sistemlerini desteklemektedir:
 
 ## Kurulum
 
-Cargo.toml dosyanıza şu şekilde ekleyin:
+Cargo.toml içinde aşağıdaki şekilde tanımlama yapın:
 
 ```toml
 [dependencies]
-parsql = "0.3.6"
+parsql = { version = "0.3.7", features = ["sqlite"] }
 ```
 
-ve özellik seçimini yapın:
+veya PostgreSQL için:
 
 ```toml
-# SQLite için
-parsql = { version = "0.3.6", features = ["sqlite"] }
+[dependencies]
+parsql = { version = "0.3.7", features = ["postgres"] }
+```
 
-# PostgreSQL için
-parsql = { version = "0.3.6", features = ["postgres"] }
+veya Tokio PostgreSQL için:
 
-# Tokio PostgreSQL için 
-parsql = { version = "0.3.6", features = ["tokio-postgres"] }
+```toml
+[dependencies]
+parsql = { version = "0.3.7", features = ["tokio-postgres"] }
+```
 
-# Deadpool PostgreSQL için
-parsql = { version = "0.3.6", features = ["deadpool-postgres"] }
+veya Deadpool PostgreSQL için:
+
+```toml
+[dependencies]
+parsql = { version = "0.3.7", features = ["deadpool-postgres"] }
 ```
 
 ## Temel Özellikler

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Hem Pool hem de Transaction nesneleri için şu extension metodları kullanılab
 - `insert(entity)` - Kayıt ekler
 - `update(entity)` - Kayıt günceller
 - `delete(entity)` - Kayıt siler
-- `get(params)` - Tek bir kayıt getirir
-- `get_all(params)` - Birden fazla kayıt getirir
+- `fetch(params)` - Tek bir kayıt getirir
+- `fetch_all(params)` - Birden fazla kayıt getirir
 - `select(entity, to_model)` - Özel dönüştürücü fonksiyon ile tek kayıt getirir
 - `select_all(entity, to_model)` - Özel dönüştürücü fonksiyon ile çoklu kayıt getirir
 
@@ -209,7 +209,7 @@ Bu, çalıştırılan tüm SQL sorgularını konsola yazdıracaktır.
 
 ```rust
 use parsql::{
-    sqlite::{get, insert},
+    sqlite::{fetch, insert},
     macros::{Queryable, Insertable, FromRow, SqlParams},
 };
 use rusqlite::Connection;
@@ -254,7 +254,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Eklenen kayıt ID: {}", id);
     
     let get_user = GetUser::new(id);
-    let user = get(&conn, get_user)?;
+    let user = fetch(&conn, get_user)?;
     println!("Kullanıcı: {:?}", user);
     
     Ok(())

--- a/cliff.toml
+++ b/cliff.toml
@@ -25,6 +25,9 @@ body = """
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
             {{ commit.message | upper_first }}\
+            {% if commit.body %}\
+                {{ commit.body | upper_first }}\
+            {% endif %}\
     {% endfor %}
 {% endfor %}\n
 """

--- a/examples/postgres/src/transaction_sample.rs
+++ b/examples/postgres/src/transaction_sample.rs
@@ -104,7 +104,7 @@ pub fn transaction_with_crud_ops(client: &mut Client) -> Result<(), Error> {
         state: 0,
     };
     
-    let user = tx.get(&get_user)?;
+    let user = tx.fetch(&get_user)?;
     println!("Güncellenmiş kullanıcı: {:?}", user);
     
     // Transaction'ı commit et

--- a/examples/tokio-deadpool-postgres/Cargo.toml
+++ b/examples/tokio-deadpool-postgres/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 license.workspace = true
 
 [dependencies]
-parsql-deadpool-postgres = { path = "../../parsql-deadpool-postgres" }
+parsql = { path = "../../", version = "0.3.6", features = ["deadpool-postgres"] }
 tokio = { version = "1.41.1", features = ["full"] }
 deadpool-postgres = { version = "0.14.1", features = ["rt_tokio_1"]}
 tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4"] }

--- a/examples/tokio-deadpool-postgres/src/main.rs
+++ b/examples/tokio-deadpool-postgres/src/main.rs
@@ -6,7 +6,7 @@ use crate::config::DatabaseConfig;
 use crate::models::{UserInsert, UserUpdate, UserDelete, UserById, UsersByState, UserStatusQuery};
 use crate::repository::UserRepository;
 use dotenv::dotenv;
-use parsql_deadpool_postgres::Error;
+use parsql::deadpool_postgres::Error;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[tokio::main]

--- a/examples/tokio-deadpool-postgres/src/models.rs
+++ b/examples/tokio-deadpool-postgres/src/models.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
-use parsql_deadpool_postgres::macros::{Deletable, Insertable, Queryable, Updateable, FromRow as DeriveFromRow, SqlParams as DeriveSqlParams, UpdateParams as DeriveUpdateParams};
-use parsql_deadpool_postgres::{SqlQuery, SqlParams, UpdateParams, FromRow};
+use parsql::macros::{Deletable, Insertable, Queryable, Updateable, FromRow as DeriveFromRow, SqlParams as DeriveSqlParams, UpdateParams as DeriveUpdateParams};
+use parsql::deadpool_postgres::{SqlQuery, SqlParams, UpdateParams, FromRow};
 use serde::{Deserialize, Serialize};
 use tokio_postgres::{types::ToSql, Row, Error};
 

--- a/examples/tokio-deadpool-postgres/src/repository.rs
+++ b/examples/tokio-deadpool-postgres/src/repository.rs
@@ -1,5 +1,5 @@
 use deadpool_postgres::Pool;
-use parsql_deadpool_postgres::{delete, get, get_all, insert, select_all, update, Error};
+use parsql::deadpool_postgres::{delete, get, get_all, insert, select_all, update, Error};
 use tokio_postgres::Row as PgRow;
 
 use crate::models::{UserById, UserDelete, UserInsert, UserUpdate, UsersByState, UserStatusQuery};

--- a/parsql-deadpool-postgres/Cargo.toml
+++ b/parsql-deadpool-postgres/Cargo.toml
@@ -14,7 +14,7 @@ license.workspace = true
 postgres = { version = "0.19.10" }
 tokio-postgres = { version = "0.7.13" }
 deadpool-postgres = { version = "0.14.1" }
-async-trait = "0.1.87"
+async-trait = "0.1.88"
 
 [dependencies.parsql-macros]
 workspace = true

--- a/parsql-deadpool-postgres/README.en.md
+++ b/parsql-deadpool-postgres/README.en.md
@@ -56,8 +56,8 @@ Add to your Cargo.toml file as follows:
 ```toml
 [dependencies]
 # For Deadpool PostgreSQL
-parsql-deadpool-postgres = "0.3.2"
-parsql-macros = "0.3.2"
+parsql-deadpool-postgres = "0.3.7"
+parsql-macros = "0.3.7"
 deadpool-postgres = "0.14"
 tokio-postgres = "0.7"
 tokio = { version = "1", features = ["full"] }

--- a/parsql-deadpool-postgres/README.md
+++ b/parsql-deadpool-postgres/README.md
@@ -56,8 +56,8 @@ Cargo.toml dosyanıza şu şekilde ekleyin:
 ```toml
 [dependencies]
 # Deadpool PostgreSQL için
-parsql-deadpool-postgres = "0.3.2"
-parsql-macros = "0.3.2"
+parsql-deadpool-postgres = "0.3.7"
+parsql-macros = "0.3.7"
 deadpool-postgres = "0.14"
 tokio-postgres = "0.7"
 tokio = { version = "1", features = ["full"] }

--- a/parsql-deadpool-postgres/src/pool_extensions.rs
+++ b/parsql-deadpool-postgres/src/pool_extensions.rs
@@ -58,7 +58,7 @@ pub trait CrudOps {
     /// 
     /// # Dönüş Değeri
     /// * `Result<T, Error>` - Getirilen kayıt veya hata
-    async fn get<T>(&self, params: &T) -> Result<T, Error>
+    async fn fetch<T>(&self, params: &T) -> Result<T, Error>
     where
         T: SqlQuery + FromRow + SqlParams + Send + Sync;
     
@@ -69,7 +69,7 @@ pub trait CrudOps {
     /// 
     /// # Dönüş Değeri
     /// * `Result<Vec<T>, Error>` - Getirilen kayıtlar veya hata
-    async fn get_all<T>(&self, params: &T) -> Result<Vec<T>, Error>
+    async fn fetch_all<T>(&self, params: &T) -> Result<Vec<T>, Error>
     where
         T: SqlQuery + FromRow + SqlParams + Send + Sync;
     
@@ -148,7 +148,7 @@ impl CrudOps for Pool {
         client.execute(&sql, &params).await
     }
 
-    async fn get<T>(&self, params: &T) -> Result<T, Error>
+    async fn fetch<T>(&self, params: &T) -> Result<T, Error>
     where
         T: SqlQuery + FromRow + SqlParams + Send + Sync
     {
@@ -164,7 +164,7 @@ impl CrudOps for Pool {
         T::from_row(&row)
     }
 
-    async fn get_all<T>(&self, params: &T) -> Result<Vec<T>, Error>
+    async fn fetch_all<T>(&self, params: &T) -> Result<Vec<T>, Error>
     where
         T: SqlQuery + FromRow + SqlParams + Send + Sync
     {

--- a/parsql-macros/README.en.md
+++ b/parsql-macros/README.en.md
@@ -41,16 +41,16 @@ and select the feature you need:
 
 ```toml
 # For SQLite
-parsql-macros = { version = "0.3.2", features = ["sqlite"] }
+parsql-macros = { version = "0.3.7", features = ["sqlite"] }
 
 # For PostgreSQL
-parsql-macros = { version = "0.3.2", features = ["postgres"] }
+parsql-macros = { version = "0.3.7", features = ["postgres"] }
 
 # For Tokio PostgreSQL
-parsql-macros = { version = "0.3.2", features = ["tokio-postgres"] }
+parsql-macros = { version = "0.3.7", features = ["tokio-postgres"] }
 
 # For Deadpool PostgreSQL
-parsql-macros = { version = "0.3.2", features = ["deadpool-postgres"] }
+parsql-macros = { version = "0.3.7", features = ["deadpool-postgres"] }
 ```
 
 ## Security Features

--- a/parsql-macros/README.md
+++ b/parsql-macros/README.md
@@ -34,23 +34,23 @@ Cargo.toml dosyanıza şu şekilde ekleyin:
 
 ```toml
 [dependencies]
-parsql-macros = "0.3.2"
+parsql-macros = "0.3.7"
 ```
 
 ve özellik seçimini yapın:
 
 ```toml
 # SQLite için
-parsql-macros = { version = "0.3.2", features = ["sqlite"] }
+parsql-macros = { version = "0.3.7", features = ["sqlite"] }
 
 # PostgreSQL için
-parsql-macros = { version = "0.3.2", features = ["postgres"] }
+parsql-macros = { version = "0.3.7", features = ["postgres"] }
 
 # Tokio PostgreSQL için
-parsql-macros = { version = "0.3.2", features = ["tokio-postgres"] }
+parsql-macros = { version = "0.3.7", features = ["tokio-postgres"] }
 
 # Deadpool PostgreSQL için
-parsql-macros = { version = "0.3.2", features = ["deadpool-postgres"] }
+parsql-macros = { version = "0.3.7", features = ["deadpool-postgres"] }
 ```
 
 ## Güvenlik Özellikleri

--- a/parsql-postgres/README.en.md
+++ b/parsql-postgres/README.en.md
@@ -52,7 +52,7 @@ Add to your Cargo.toml file as follows:
 
 ```toml
 [dependencies]
-parsql = { version = "0.3.2", features = ["postgres"] }
+parsql = { version = "0.3.7", features = ["postgres"] }
 ```
 
 or if you want to use this package directly:

--- a/parsql-postgres/README.md
+++ b/parsql-postgres/README.md
@@ -52,7 +52,7 @@ Cargo.toml dosyanıza şu şekilde ekleyin:
 
 ```toml
 [dependencies]
-parsql = { version = "0.3.2", features = ["postgres"] }
+parsql = { version = "0.3.7", features = ["postgres"] }
 ```
 
 veya doğrudan bu paketi kullanmak isterseniz:

--- a/parsql-postgres/benches/postgres_benches.rs
+++ b/parsql-postgres/benches/postgres_benches.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use parsql_macros::{Insertable, FromRow, Queryable, SqlParams};
-use parsql_postgres::{ get, insert, FromRow, SqlParams, SqlQuery};
+use parsql_postgres::{ fetch, fetch_all, insert, FromRow, SqlParams, SqlQuery};
 use postgres::{types::ToSql, Client, NoTls, Row, Error};
 
 #[derive(Insertable, SqlParams)]
@@ -62,7 +62,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 email: "SampleEmail".to_string(),
                 state: 1,
             });
-            let _ = get(&mut db, &user);
+            let _ = fetch(&mut db, &user);
         })
     });
 }

--- a/parsql-sqlite/README.en.md
+++ b/parsql-sqlite/README.en.md
@@ -7,7 +7,7 @@ SQLite integration crate for parsql. This package provides synchronous APIs that
 - Synchronous SQLite operations
 - Automatic SQL query generation
 - Secure parameter management
-- Generic CRUD operations (get, insert, update)
+- Generic CRUD operations (fetch, insert, update)
 - Conversion of database rows to structs
 - Automatic protection against SQL Injection attacks
 - Transaction support
@@ -42,7 +42,7 @@ let query = UserQuery {
 
 // Generated query: "SELECT * FROM users WHERE username = ? AND status = ?"
 // Parameters are safely sent as: [user_input, 1]
-let user = get(&conn, query)?;
+let user = fetch(&conn, &query)?;
 ```
 
 ## Installation
@@ -66,8 +66,8 @@ parsql-macros = "0.3.2"
 
 parsql-sqlite offers two different approaches for working with SQLite databases:
 
-1. Function-based approach (`get`, `insert`, `update`, etc.)
-2. Extension method approach (`conn.get()`, `conn.insert()`, etc.) - `CrudOps` trait
+1. Function-based approach (`fetch`, `insert`, `update`, etc.)
+2. Extension method approach (`conn.fetch()`, `conn.insert()`, etc.) - `CrudOps` trait
 
 ### Establishing a Connection
 
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
 
 ```rust
 use rusqlite::{Connection, Result};
-use parsql::sqlite::{get, insert};
+use parsql::sqlite::{fetch, insert};
 use parsql::macros::{Insertable, SqlParams, Queryable, FromRow};
 
 #[derive(Insertable, SqlParams)]
@@ -133,7 +133,7 @@ fn main() -> Result<()> {
         name: String::new(),
         email: String::new(),
     };
-    let user = get(&conn, &get_user)?;
+    let user = fetch(&conn, &get_user)?;
     
     println!("User: {:?}", user);
     Ok(())
@@ -179,7 +179,7 @@ fn main() -> Result<()> {
         name: String::new(),
         email: String::new(),
     };
-    let user = conn.get(&get_user)?;
+    let user = conn.fetch(&get_user)?;
     
     println!("User: {:?}", user);
     Ok(())
@@ -236,7 +236,7 @@ fn main() -> Result<()> {
         name: String::new(),
         email: String::new(),
     };
-    let user = tx.get(&param)?;
+    let user = tx.fetch(&param)?;
     
     // Commit the transaction
     tx.commit()?;
@@ -304,7 +304,7 @@ fn main() -> Result<()> {
 use parsql::{
     core::Queryable,
     macros::{FromRow, Queryable, SqlParams},
-    sqlite::{FromRow, SqlParams, get},
+    sqlite::{FromRow, SqlParams, fetch},
 };
 use rusqlite::{types::ToSql, Row};
 
@@ -334,7 +334,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     // Usage
     let get_user = GetUser::new(1);
-    let get_result = get(&conn, get_user)?;
+    let get_result = fetch(&conn, get_user)?;
     
     println!("User: {:?}", get_result);
     Ok(())
@@ -521,7 +521,7 @@ This will print all queries generated for SQLite to the console.
 Use Rust's `Result` mechanism to catch and handle errors that may occur during SQLite operations:
 
 ```rust
-match get(&conn, get_user) {
+match fetch(&conn, get_user) {
     Ok(user) => println!("User found: {:?}", user),
     Err(e) => eprintln!("Error occurred: {}", e),
 }

--- a/parsql-sqlite/README.en.md
+++ b/parsql-sqlite/README.en.md
@@ -51,15 +51,15 @@ Add to your Cargo.toml file as follows:
 
 ```toml
 [dependencies]
-parsql = { version = "0.3.2", features = ["sqlite"] }
+parsql = { version = "0.3.7", features = ["sqlite"] }
 ```
 
 or if you want to use this package directly:
 
 ```toml
 [dependencies]
-parsql-sqlite = "0.3.2"
-parsql-macros = "0.3.2"
+parsql-sqlite = "0.3.7"
+parsql-macros = "0.3.7"
 ```
 
 ## Usage
@@ -529,4 +529,4 @@ match fetch(&conn, get_user) {
 
 ## Complete Example Project
 
-For a complete example project, see the [examples/sqlite](../examples/sqlite) directory in the main parsql repository. 
+For a complete example project, see the [examples/sqlite](../examples/sqlite) directory in the main parsql repository.

--- a/parsql-sqlite/README.md
+++ b/parsql-sqlite/README.md
@@ -51,15 +51,15 @@ Cargo.toml dosyanıza şu şekilde ekleyin:
 
 ```toml
 [dependencies]
-parsql = { version = "0.3.2", features = ["sqlite"] }
+parsql = { version = "0.3.7", features = ["sqlite"] }
 ```
 
 veya doğrudan bu paketi kullanmak isterseniz:
 
 ```toml
 [dependencies]
-parsql-sqlite = "0.3.2"
-parsql-macros = "0.3.2"
+parsql-sqlite = "0.3.7"
+parsql-macros = "0.3.7"
 ```
 
 ## Kullanım

--- a/parsql-sqlite/README.md
+++ b/parsql-sqlite/README.md
@@ -7,7 +7,7 @@ Parsql için SQLite entegrasyon küfesidir. Bu paket, parsql'in SQLite veritaban
 - Senkron SQLite işlemleri
 - Otomatik SQL sorgu oluşturma
 - Güvenli parametre yönetimi
-- Generic CRUD işlemleri (get, insert, update)
+- Generic CRUD işlemleri (fetch, insert, update)
 - Veritabanı satırlarını struct'lara dönüştürme
 - SQL Injection saldırılarına karşı otomatik koruma
 - Transaction desteği
@@ -42,7 +42,7 @@ let query = UserQuery {
 
 // Oluşturulan sorgu: "SELECT * FROM users WHERE username = ? AND status = ?"
 // Parametreler güvenli bir şekilde: [kullanici_girdisi, 1] olarak gönderilir
-let user = get(&conn, query)?;
+let user = fetch(&conn, &query)?;
 ```
 
 ## Kurulum
@@ -66,8 +66,8 @@ parsql-macros = "0.3.2"
 
 Parsql-sqlite, SQLite veritabanlarıyla çalışmak için iki farklı yaklaşım sunar:
 
-1. Fonksiyon tabanlı yaklaşım (`get`, `insert`, `update`, vb.)
-2. Extension metot yaklaşımı (`conn.get()`, `conn.insert()`, vb.) - `CrudOps` trait
+1. Fonksiyon tabanlı yaklaşım (`fetch`, `insert`, `update`, vb.)
+2. Extension metot yaklaşımı (`conn.fetch()`, `conn.insert()`, vb.) - `CrudOps` trait
 
 ### Bağlantı Kurma
 
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
 
 ```rust
 use rusqlite::{Connection, Result};
-use parsql::sqlite::{get, insert};
+use parsql::sqlite::{fetch, insert};
 use parsql::macros::{Insertable, SqlParams, Queryable, FromRow};
 
 #[derive(Insertable, SqlParams)]
@@ -133,7 +133,7 @@ fn main() -> Result<()> {
         name: String::new(),
         email: String::new(),
     };
-    let user = get(&conn, &get_user)?;
+    let user = fetch(&conn, &get_user)?;
     
     println!("Kullanıcı: {:?}", user);
     Ok(())
@@ -179,7 +179,7 @@ fn main() -> Result<()> {
         name: String::new(),
         email: String::new(),
     };
-    let user = conn.get(&get_user)?;
+    let user = conn.fetch(&get_user)?;
     
     println!("Kullanıcı: {:?}", user);
     Ok(())
@@ -236,7 +236,7 @@ fn main() -> Result<()> {
         name: String::new(),
         email: String::new(),
     };
-    let user = tx.get(&param)?;
+    let user = tx.fetch(&param)?;
     
     // Transaction tamamlama
     tx.commit()?;
@@ -304,7 +304,7 @@ fn main() -> Result<()> {
 use parsql::{
     core::Queryable,
     macros::{FromRow, Queryable, SqlParams},
-    sqlite::{FromRow, SqlParams, get},
+    sqlite::{FromRow, SqlParams, fetch},
 };
 use rusqlite::{types::ToSql, Row};
 
@@ -334,7 +334,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     // Kullanımı
     let get_user = GetUser::new(1);
-    let get_result = get(&conn, get_user)?;
+    let get_result = fetch(&conn, get_user)?;
     
     println!("Kullanıcı: {:?}", get_result);
     Ok(())
@@ -521,7 +521,7 @@ Bu, SQLite için oluşturulan tüm sorguları konsola yazdıracaktır.
 SQLite işlemleri sırasında oluşabilecek hataları yakalamak ve işlemek için Rust'ın `Result` mekanizmasını kullanın:
 
 ```rust
-match get(&conn, get_user) {
+match fetch(&conn, get_user) {
     Ok(user) => println!("Kullanıcı bulundu: {:?}", user),
     Err(e) => eprintln!("Hata oluştu: {}", e),
 }

--- a/parsql-sqlite/src/crud_ops.rs
+++ b/parsql-sqlite/src/crud_ops.rs
@@ -87,7 +87,7 @@ pub trait CrudOps {
     /// 
     /// # Returns
     /// * `Result<T, Error>` - On success, returns the retrieved record; on failure, returns Error
-    fn get<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<T, Error>;
+    fn fetch<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<T, Error>;
 
     /// Retrieves multiple records from the SQLite database.
     /// 
@@ -96,7 +96,7 @@ pub trait CrudOps {
     /// 
     /// # Returns
     /// * `Result<Vec<T>, Error>` - On success, returns a vector of records; on failure, returns Error
-    fn get_all<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<Vec<T>, Error>;
+    fn fetch_all<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<Vec<T>, Error>;
 
     /// Executes a custom query and transforms the result using the provided function.
     /// 
@@ -164,7 +164,7 @@ impl CrudOps for rusqlite::Connection {
         self.execute(&sql, param_refs.as_slice())
     }
 
-    fn get<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<T, Error> {
+    fn fetch<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<T, Error> {
         let sql = T::query();
         
         if std::env::var("PARSQL_TRACE").unwrap_or_default() == "1" {
@@ -175,12 +175,17 @@ impl CrudOps for rusqlite::Connection {
         let param_refs: Vec<&dyn ToSql> = params.iter().map(|p| *p as &dyn ToSql).collect();
         
         let mut stmt = self.prepare(&sql)?;
-        let row = stmt.query_row(param_refs.as_slice(), |row| T::from_row(row))?;
+        let mut rows = stmt.query(param_refs.as_slice())?;
         
-        Ok(row)
+        if let Some(row) = rows.next()? {
+            let result = T::from_row(row)?;
+            Ok(result)
+        } else {
+            Err(Error::QueryReturnedNoRows)
+        }
     }
 
-    fn get_all<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<Vec<T>, Error> {
+    fn fetch_all<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<Vec<T>, Error> {
         let sql = T::query();
         
         if std::env::var("PARSQL_TRACE").unwrap_or_default() == "1" {
@@ -194,8 +199,8 @@ impl CrudOps for rusqlite::Connection {
         let rows = stmt.query_map(param_refs.as_slice(), |row| T::from_row(row))?;
         
         let mut results = Vec::new();
-        for row in rows {
-            results.push(row?);
+        for row_result in rows {
+            results.push(row_result?);
         }
         
         Ok(results)
@@ -450,7 +455,7 @@ pub fn delete<T: SqlQuery + SqlParams>(
     conn.delete(entity)
 }
 
-/// # get
+/// # fetch
 /// 
 /// Retrieves a single record from the database based on a specific condition.
 /// 
@@ -459,14 +464,12 @@ pub fn delete<T: SqlQuery + SqlParams>(
 /// - `entity`: Query parameter object (must implement SqlQuery, FromRow, and SqlParams traits)
 /// 
 /// ## Return Value
-/// - `Result<T, Error>`: On success, returns the retrieved record; on failure, returns Error
+/// - `Result<T, Error>`: On success, returns the queried record; on failure, returns Error
 /// 
 /// ## Struct Definition
 /// Structs used with this function should be annotated with the following derive macros:
 /// 
 /// ```rust,no_run
-/// use parsql_macros::{Queryable, FromRow, SqlParams};
-/// 
 /// #[derive(Queryable, FromRow, SqlParams)]  // Required macros
 /// #[table("table_name")]                    // Table name to query
 /// #[where_clause("id = ?")]                 // Query condition
@@ -482,7 +485,7 @@ pub fn delete<T: SqlQuery + SqlParams>(
 /// ```rust,no_run
 /// use rusqlite::{Connection, Result};
 /// use parsql_macros::{Queryable, FromRow, SqlParams};
-/// use parsql_sqlite::get;
+/// use parsql_sqlite::fetch;
 /// 
 /// fn main() -> Result<()> {
 ///     // Create database connection
@@ -508,19 +511,19 @@ pub fn delete<T: SqlQuery + SqlParams>(
 ///     };
 /// 
 ///     // Execute query
-///     let user = get(&conn, get_query)?;
+///     let user = fetch(&conn, &get_query)?;
 ///     println!("User: {:?}", user);
 ///     Ok(())
 /// }
 /// ```
-pub fn get<T: SqlQuery + FromRow + SqlParams>(
+pub fn fetch<T: SqlQuery + FromRow + SqlParams>(
     conn: &rusqlite::Connection,
     entity: &T,
 ) -> Result<T, Error> {
-    conn.get(entity)
+    conn.fetch(entity)
 }
 
-/// # get_all
+/// # fetch_all
 /// 
 /// Retrieves multiple records from the database based on a specific condition.
 /// 
@@ -529,68 +532,52 @@ pub fn get<T: SqlQuery + FromRow + SqlParams>(
 /// - `entity`: Query parameter object (must implement SqlQuery, FromRow, and SqlParams traits)
 /// 
 /// ## Return Value
-/// - `Result<Vec<T>, Error>`: On success, returns a vector of retrieved records; on failure, returns Error
-/// 
-/// ## Struct Definition
-/// Structs used with this function should be annotated with the following derive macros:
-/// 
-/// ```rust,no_run
-/// use parsql_macros::{Queryable, FromRow, SqlParams};
-/// 
-/// #[derive(Queryable, FromRow, SqlParams)]  // Required macros
-/// #[table("table_name")]                    // Table name to query
-/// #[where_clause("state = ?")]              // Query condition
-/// pub struct MyEntity {
-///     pub state: i16,                       // Field used in the condition
-///     pub field1: String,                   // Fields to retrieve
-///     pub field2: i32,
-/// }
-/// ```
+/// - `Result<Vec<T>, Error>`: On success, returns a vector of records; on failure, returns Error
 /// 
 /// ## Example Usage
 /// 
 /// ```rust,no_run
 /// use rusqlite::{Connection, Result};
 /// use parsql_macros::{Queryable, FromRow, SqlParams};
-/// use parsql_sqlite::get_all;
+/// use parsql_sqlite::fetch_all;
 /// 
 /// fn main() -> Result<()> {
 ///     // Create database connection
 ///     let conn = Connection::open("test.db")?;
-///     conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT, state INTEGER)", [])?;
-///     conn.execute("INSERT INTO users (name, email, state) VALUES ('John', 'john@example.com', 1)", [])?;
-///     conn.execute("INSERT INTO users (name, email, state) VALUES ('Jane', 'jane@example.com', 1)", [])?;
+///     conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT, active INTEGER)", [])?;
+///     conn.execute("INSERT INTO users (id, name, email, active) VALUES (1, 'John', 'john@example.com', 1)", [])?;
+///     conn.execute("INSERT INTO users (id, name, email, active) VALUES (2, 'Jane', 'jane@example.com', 1)", [])?;
 /// 
 ///     // Define a query
 ///     #[derive(Queryable, FromRow, SqlParams)]
 ///     #[table("users")]
-///     #[where_clause("state = ?")]
+///     #[where_clause("active = ?")]
 ///     pub struct GetActiveUsers {
 ///         pub id: i64,
 ///         pub name: String,
 ///         pub email: String,
-///         pub state: i16,
+///         pub active: i32,
 ///     }
 /// 
 ///     // Create query parameters (get all active users)
-///     let get_query = GetActiveUsers {
+///     let query = GetActiveUsers {
 ///         id: 0,
 ///         name: String::new(),
 ///         email: String::new(),
-///         state: 1,
+///         active: 1,
 ///     };
 /// 
 ///     // Execute query
-///     let users = get_all(&conn, get_query)?;
+///     let users = fetch_all(&conn, &query)?;
 ///     println!("Active users: {:?}", users);
 ///     Ok(())
 /// }
 /// ```
-pub fn get_all<T: SqlQuery + FromRow + SqlParams>(
+pub fn fetch_all<T: SqlQuery + FromRow + SqlParams>(
     conn: &rusqlite::Connection,
     entity: &T,
 ) -> Result<Vec<T>, Error> {
-    conn.get_all(entity)
+    conn.fetch_all(entity)
 }
 
 /// # select

--- a/parsql-sqlite/src/crud_ops.rs
+++ b/parsql-sqlite/src/crud_ops.rs
@@ -98,6 +98,42 @@ pub trait CrudOps {
     /// * `Result<Vec<T>, Error>` - On success, returns a vector of records; on failure, returns Error
     fn fetch_all<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<Vec<T>, Error>;
 
+    /// Retrieves a single record from the SQLite database.
+    /// 
+    /// # Deprecated
+    /// This function has been renamed to `fetch`. Please use `fetch` instead.
+    /// 
+    /// # Arguments
+    /// * `entity` - Data object containing query parameters (must implement SqlQuery, FromRow, and SqlParams traits)
+    /// 
+    /// # Returns
+    /// * `Result<T, Error>` - On success, returns the retrieved record; on failure, returns Error
+    #[deprecated(
+        since = "0.3.7",
+        note = "Renamed to `fetch`. Please use `fetch` function instead."
+    )]
+    fn get<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<T, Error> {
+        self.fetch(entity)
+    }
+
+    /// Retrieves multiple records from the SQLite database.
+    /// 
+    /// # Deprecated
+    /// This function has been renamed to `fetch_all`. Please use `fetch_all` instead.
+    /// 
+    /// # Arguments
+    /// * `entity` - Data object containing query parameters (must implement SqlQuery, FromRow, and SqlParams traits)
+    /// 
+    /// # Returns
+    /// * `Result<Vec<T>, Error>` - A vector of retrieved records or an error
+    #[deprecated(
+        since = "0.3.7",
+        note = "Renamed to `fetch_all`. Please use `fetch_all` function instead."
+    )]
+    fn get_all<T: SqlQuery + FromRow + SqlParams>(&self, entity: &T) -> Result<Vec<T>, Error> {
+        self.fetch_all(entity)
+    }
+
     /// Executes a custom query and transforms the result using the provided function.
     /// 
     /// # Arguments
@@ -580,6 +616,54 @@ pub fn fetch_all<T: SqlQuery + FromRow + SqlParams>(
     conn.fetch_all(entity)
 }
 
+/// # get
+/// 
+/// Retrieves a single record from the database based on a specific condition.
+/// 
+/// # Deprecated
+/// This function has been renamed to `fetch`. Please use `fetch` instead.
+/// 
+/// ## Parameters
+/// - `conn`: SQLite database connection
+/// - `entity`: Query parameter object (must implement SqlQuery, FromRow, and SqlParams traits)
+/// 
+/// ## Return Value
+/// - `Result<T, Error>`: On success, returns the queried record; on failure, returns Error
+#[deprecated(
+    since = "0.3.7",
+    note = "Renamed to `fetch`. Please use `fetch` function instead."
+)]
+pub fn get<T: SqlQuery + FromRow + SqlParams>(
+    conn: &rusqlite::Connection,
+    entity: &T,
+) -> Result<T, Error> {
+    fetch(conn, entity)
+}
+
+/// # get_all
+/// 
+/// Retrieves multiple records from the database based on a specific condition.
+/// 
+/// # Deprecated
+/// This function has been renamed to `fetch_all`. Please use `fetch_all` instead.
+/// 
+/// ## Parameters
+/// - `conn`: SQLite database connection
+/// - `entity`: Query parameter object (must implement SqlQuery, FromRow, and SqlParams traits)
+/// 
+/// ## Return Value
+/// - `Result<Vec<T>, Error>`: On success, returns a vector of records; on failure, returns Error
+#[deprecated(
+    since = "0.3.7",
+    note = "Renamed to `fetch_all`. Please use `fetch_all` function instead."
+)]
+pub fn get_all<T: SqlQuery + FromRow + SqlParams>(
+    conn: &rusqlite::Connection,
+    entity: &T,
+) -> Result<Vec<T>, Error> {
+    fetch_all(conn, entity)
+}
+
 /// # select
 /// 
 /// Executes a custom SELECT query and maps the result to a model using a provided mapping function.
@@ -634,7 +718,7 @@ pub fn fetch_all<T: SqlQuery + FromRow + SqlParams>(
 ///     };
 /// 
 ///     // Execute query with custom mapping
-///     let user = select(&mut conn, get_query, to_user)?;
+///     let user = select(&conn, &get_query, to_user)?;
 ///     println!("User: {:?}", user);
 ///     Ok(())
 /// }
@@ -707,7 +791,7 @@ where
 ///     };
 /// 
 ///     // Execute query with custom mapping
-///     let users = select_all(&mut conn, get_query, to_user)?;
+///     let users = select_all(&conn, &get_query, to_user)?;
 ///     println!("Active users: {:?}", users);
 ///     Ok(())
 /// }

--- a/parsql-sqlite/src/lib.rs
+++ b/parsql-sqlite/src/lib.rs
@@ -16,7 +16,7 @@
 //! 
 //! ```rust,no_run
 //! use rusqlite::{Connection, Result};
-//! use parsql::sqlite::{get, insert};
+//! use parsql::sqlite::{fetch, insert};
 //! 
 //! #[derive(Insertable, SqlParams)]
 //! #[table("users")]
@@ -47,7 +47,7 @@
 //!     
 //!     // Get the user back
 //!     let get_user = GetUser::new(id as i32);
-//!     let user = get(&conn, &get_user)?;
+//!     let user = fetch(&conn, &get_user)?;
 //!     
 //!     println!("User: {:?}", user);
 //!     Ok(())
@@ -96,7 +96,7 @@
 //!         name: String::new(),
 //!         email: String::new(),
 //!     };
-//!     let user = conn.get(&get_user)?;
+//!     let user = conn.fetch(&get_user)?;
 //!     
 //!     println!("User: {:?}", user);
 //!     Ok(())
@@ -169,8 +169,8 @@ pub use crud_ops::{
     select_all, 
     update, 
     delete, 
-    get, 
-    get_all,
+    fetch, 
+    fetch_all,
     CrudOps,
 };
 

--- a/parsql-sqlite/src/lib.rs
+++ b/parsql-sqlite/src/lib.rs
@@ -154,6 +154,23 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## Installation
+//!
+//! Add to your Cargo.toml file as follows:
+//!
+//! ```toml
+//! [dependencies]
+//! parsql = { version = "0.3.7", features = ["sqlite"] }
+//! ```
+//!
+//! or if you want to use this package directly:
+//!
+//! ```toml
+//! [dependencies]
+//! parsql-sqlite = "0.3.7"
+//! parsql-macros = "0.3.7"
+//! ```
 
 pub mod crud_ops;
 pub mod transactional_ops;

--- a/parsql-sqlite/src/transactional_ops.rs
+++ b/parsql-sqlite/src/transactional_ops.rs
@@ -685,7 +685,7 @@ pub fn tx_fetch_all<'a, T: SqlQuery + FromRow + SqlParams>(
 /// # Returns
 /// * `Result<(Transaction<'_>, T), Error>` - Transaction and the retrieved record or an error
 #[deprecated(
-    since = "0.3.6",
+    since = "0.3.7",
     note = "Renamed to `tx_fetch`. Please use `tx_fetch` function instead."
 )]
 pub fn tx_get<'a, T: SqlQuery + FromRow + SqlParams>(
@@ -707,7 +707,7 @@ pub fn tx_get<'a, T: SqlQuery + FromRow + SqlParams>(
 /// # Returns
 /// * `Result<(Transaction<'_>, Vec<T>), Error>` - Transaction and a vector of retrieved records or an error
 #[deprecated(
-    since = "0.3.6",
+    since = "0.3.7",
     note = "Renamed to `tx_fetch_all`. Please use `tx_fetch_all` function instead."
 )]
 pub fn tx_get_all<'a, T: SqlQuery + FromRow + SqlParams>(

--- a/parsql-tokio-postgres/Cargo.toml
+++ b/parsql-tokio-postgres/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 [dependencies]
 postgres = { version = "0.19.10" }
 tokio-postgres = { version = "0.7.13" }
-async-trait = "0.1.87"
+async-trait = "0.1.88"
 
 [dependencies.parsql-macros]
 workspace = true

--- a/parsql-tokio-postgres/README.en.md
+++ b/parsql-tokio-postgres/README.en.md
@@ -7,7 +7,7 @@ Tokio PostgreSQL integration crate for parsql. This package provides asynchronou
 - Asynchronous PostgreSQL operations (with tokio runtime)
 - Automatic SQL query generation
 - Secure parameter management
-- Generic CRUD operations (get, insert, update, delete)
+- Generic CRUD operations (fetch, insert, update, delete)
 - Conversion of database rows to structs
 - Deadpool connection pool support
 - Automatic protection against SQL Injection attacks
@@ -46,7 +46,7 @@ let query = UserQuery {
 
 // Generated query: "SELECT * FROM users WHERE username = $1 AND status = $2"
 // Parameters are safely sent as: [user_input, 1]
-let user = get(&client, query).await?;
+let user = fetch(&client, query).await?;
 ```
 
 ## Installation
@@ -149,8 +149,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 There are two approaches provided for performing database operations:
 
-1. Function-based approach (`get`, `insert`, `update`, etc.)
-2. Extension method approach (`client.get()`, `client.insert()`, etc.) - `CrudOps` trait
+1. Function-based approach (`fetch`, `insert`, `update`, etc.)
+2. Extension method approach (`client.fetch()`, `client.insert()`, etc.) - `CrudOps` trait
 
 ### Extension Method Approach (CrudOps Trait)
 
@@ -194,20 +194,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     // Using extension method
     let get_user = GetUser::new(1);
-    let user = client.get(get_user).await?;
+    let user = client.fetch(get_user).await?;
     
     println!("User: {:?}", user);
     Ok(())
 }
 ```
 
-### Reading Data (Get)
+### Reading Data (Fetch)
 
 ```rust
 use parsql::{
     core::Queryable,
     macros::{FromRow, Queryable, SqlParams},
-    tokio_postgres::{FromRow, SqlParams, get, CrudOps},
+    tokio_postgres::{FromRow, SqlParams, fetch, CrudOps},
 };
 use tokio_postgres::{types::ToSql, Row};
 
@@ -247,11 +247,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     // Usage (function approach)
     let get_user = GetUser::new(1);
-    let get_result = get(&client, get_user).await?;
+    let get_result = fetch(&client, get_user).await?;
     
     // or (extension method approach)
     let get_user = GetUser::new(1);
-    let get_result = client.get(get_user).await?;
+    let get_result = client.fetch(get_user).await?;
     
     println!("User: {:?}", get_result);
     Ok(())
@@ -598,7 +598,7 @@ async fn handle_database() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
     
-    let result = match get(&client, user_query).await {
+    let result = match fetch(&client, user_query).await {
         Ok(user) => {
             println!("User found: {:?}", user);
             // Operation successful

--- a/parsql-tokio-postgres/README.en.md
+++ b/parsql-tokio-postgres/README.en.md
@@ -56,10 +56,10 @@ Add to your Cargo.toml file as follows:
 ```toml
 [dependencies]
 # For Tokio PostgreSQL
-parsql = { version = "0.3.2", features = ["tokio-postgres"] }
+parsql = { version = "0.3.7", features = ["tokio-postgres"] }
 
-# or for using with deadpool connection pool
-parsql = { version = "0.3.2", features = ["deadpool-postgres"] }
+# For Deadpool PostgreSQL
+parsql = { version = "0.3.7", features = ["deadpool-postgres"] }
 ```
 
 or if you want to use this package directly:

--- a/parsql-tokio-postgres/README.md
+++ b/parsql-tokio-postgres/README.md
@@ -56,10 +56,10 @@ Cargo.toml dosyanıza şu şekilde ekleyin:
 ```toml
 [dependencies]
 # Tokio PostgreSQL için
-parsql = { version = "0.3.2", features = ["tokio-postgres"] }
+parsql = { version = "0.3.7", features = ["tokio-postgres"] }
 
-# veya deadpool bağlantı havuzu ile kullanmak için
-parsql = { version = "0.3.2", features = ["deadpool-postgres"] }
+# Deadpool PostgreSQL için
+parsql = { version = "0.3.7", features = ["deadpool-postgres"] }
 ```
 
 veya doğrudan bu paketi kullanmak isterseniz:

--- a/parsql-tokio-postgres/src/crud_ops.rs
+++ b/parsql-tokio-postgres/src/crud_ops.rs
@@ -152,11 +152,11 @@ pub trait CrudOps {
     ///     email: Default::default(),
     /// };
     ///
-    /// let user = client.get(query).await?;
+    /// let user = client.fetch(query).await?;
     /// # Ok(())
     /// # }
     /// ```
-    async fn get<T>(&self, params: T) -> Result<T, Error>
+    async fn fetch<T>(&self, params: T) -> Result<T, Error>
     where
         T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static;
 
@@ -194,11 +194,11 @@ pub trait CrudOps {
     ///     state: 1, // active users
     /// };
     ///
-    /// let users = client.get_all(query).await?;
+    /// let users = client.fetch_all(query).await?;
     /// # Ok(())
     /// # }
     /// ```
-    async fn get_all<T>(&self, params: T) -> Result<Vec<T>, Error>
+    async fn fetch_all<T>(&self, params: T) -> Result<Vec<T>, Error>
     where
         T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static;
 
@@ -305,6 +305,28 @@ pub trait CrudOps {
         T: SqlQuery + SqlParams + Send + Sync + 'static,
         F: Fn(&Row) -> R + Send + Sync + 'static,
         R: Send + 'static;
+
+    #[deprecated(
+        since = "0.2.0",
+        note = "Renamed to `fetch`. Please use `fetch` function instead."
+    )]
+    async fn get<T>(&self, params: T) -> Result<T, Error>
+    where
+        T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static,
+    {
+        self.fetch(params).await
+    }
+
+    #[deprecated(
+        since = "0.2.0",
+        note = "Renamed to `fetch_all`. Please use `fetch_all` function instead."
+    )]
+    async fn get_all<T>(&self, params: T) -> Result<Vec<T>, Error>
+    where
+        T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static,
+    {
+        self.fetch_all(params).await
+    }
 }
 
 #[async_trait::async_trait]
@@ -367,7 +389,7 @@ impl CrudOps for Client {
         self.execute(&sql, &params).await
     }
 
-    async fn get<T>(&self, params: T) -> Result<T, Error>
+    async fn fetch<T>(&self, params: T) -> Result<T, Error>
     where
         T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static,
     {
@@ -387,7 +409,7 @@ impl CrudOps for Client {
         T::from_row(&row)
     }
 
-    async fn get_all<T>(&self, params: T) -> Result<Vec<T>, Error>
+    async fn fetch_all<T>(&self, params: T) -> Result<Vec<T>, Error>
     where
         T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static,
     {
@@ -524,7 +546,7 @@ where
     client.delete(entity).await
 }
 
-/// # get
+/// # fetch
 /// 
 /// Retrieves a single record from the database and converts it to a struct.
 /// 
@@ -534,17 +556,17 @@ where
 /// 
 /// ## Return Value
 /// - `Result<T, Error>`: On success, returns the retrieved record as a struct; on failure, returns Error
-pub async fn get<T>(
+pub async fn fetch<T>(
     client: &Client,
     params: T,
 ) -> Result<T, Error>
 where
     T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static
 {
-    client.get(params).await
+    client.fetch(params).await
 }
 
-/// # get_all
+/// # fetch_all
 /// 
 /// Retrieves multiple records from the database.
 /// 
@@ -554,14 +576,14 @@ where
 /// 
 /// ## Return Value
 /// - `Result<Vec<T>, Error>`: On success, returns the list of found records; on failure, returns Error
-pub async fn get_all<T>(
+pub async fn fetch_all<T>(
     client: &Client,
     params: T,
 ) -> Result<Vec<T>, Error>
 where
     T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static
 {
-    client.get_all(params).await
+    client.fetch_all(params).await
 }
 
 /// # select
@@ -612,4 +634,60 @@ where
     R: Send + 'static
 {
     client.select_all(entity, to_model).await
+}
+
+// DEPRECATED FUNCTIONS - For backward compatibility
+
+/// # get
+/// 
+/// Retrieves a single record from the database and converts it to a struct.
+/// 
+/// # Deprecated
+/// This function has been renamed to `fetch`. Please use `fetch` instead.
+/// 
+/// # Arguments
+/// * `client` - Database connection client
+/// * `params` - Query parameters (must implement SqlQuery, FromRow, and SqlParams traits)
+/// 
+/// # Return Value
+/// * `Result<T, Error>` - On success, returns the retrieved record; on failure, returns Error
+#[deprecated(
+    since = "0.2.0",
+    note = "Renamed to `fetch`. Please use `fetch` function instead."
+)]
+pub async fn get<T>(
+    client: &Client,
+    params: T,
+) -> Result<T, Error>
+where
+    T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static
+{
+    fetch(client, params).await
+}
+
+/// # get_all
+/// 
+/// Retrieves multiple records from the database.
+/// 
+/// # Deprecated
+/// This function has been renamed to `fetch_all`. Please use `fetch_all` instead.
+/// 
+/// # Arguments
+/// * `client` - Database connection client
+/// * `params` - Query parameters (must implement SqlQuery, FromRow, and SqlParams traits)
+/// 
+/// # Return Value
+/// * `Result<Vec<T>, Error>` - On success, returns the list of found records; on failure, returns Error
+#[deprecated(
+    since = "0.2.0",
+    note = "Renamed to `fetch_all`. Please use `fetch_all` function instead."
+)]
+pub async fn get_all<T>(
+    client: &Client,
+    params: T,
+) -> Result<Vec<T>, Error>
+where
+    T: SqlQuery + FromRow + SqlParams + Send + Sync + 'static
+{
+    fetch_all(client, params).await
 }

--- a/parsql-tokio-postgres/src/lib.rs
+++ b/parsql-tokio-postgres/src/lib.rs
@@ -70,7 +70,7 @@
 //!     
 //!     // Get the user back
 //!     let get_user = GetUser::new(id as i32);
-//!     let user = client.get(get_user).await?;
+//!     let user = client.fetch(get_user).await?;
 //!     
 //!     println!("User: {:?}", user);
 //!     Ok(())
@@ -95,7 +95,7 @@
 //!     let client = pool.get().await?;
 //!     
 //!     // Use extension methods
-//!     let users = client.get_all(active_users_query).await?;
+//!     let users = client.fetch_all(active_users_query).await?;
 //!     
 //!     Ok(())
 //! }
@@ -161,10 +161,17 @@ pub use crate::crud_ops::{
     insert,
     update,
     delete,
-    get,
-    get_all,
+    fetch,
+    fetch_all,
     select,
     select_all
+};
+
+// Geriye dönük uyumluluk için eski fonksiyonları deprecated olarak dışa aktaralım
+#[allow(deprecated)]
+pub use crate::crud_ops::{
+    get,
+    get_all
 };
 
 pub use parsql_macros as macros;
@@ -177,10 +184,12 @@ pub use parsql_macros as macros;
 /// - `tx_insert`: Insert a record within a transaction
 /// - `tx_update`: Update records within a transaction
 /// - `tx_delete`: Delete records within a transaction
-/// - `tx_get`: Get a single record within a transaction
-/// - `tx_get_all`: Get multiple records within a transaction
+/// - `tx_fetch`: Get a single record within a transaction  
+/// - `tx_fetch_all`: Get multiple records within a transaction
 /// - `tx_select`: Execute a custom query and transform a single result within a transaction
 /// - `tx_select_all`: Execute a custom query and transform multiple results within a transaction
+/// - `tx_get`: (Deprecated) Get a single record within a transaction
+/// - `tx_get_all`: (Deprecated) Get multiple records within a transaction
 pub use transaction_ops as transactional;
 
 /// Trait for generating SQL queries.


### PR DESCRIPTION
* Kod Değişiklikleri

- CrudOps trait'inde get ve get_all metodları fetch ve fetch_all olarak yeniden adlandırıldı
- Eski metodlar geriye dönük uyumluluk için #[deprecated] olarak işaretlendi
- transactional_ops.rs dosyasında tx_get ve tx_get_all fonksiyonları tx_fetch ve tx_fetch_all olarak yeniden adlandırıldı
- lib.rs dosyasında yeni metod adları dışa aktarıldı

* Belgelendirme Değişiklikleri

- README.md ve README.en.md dosyalarındaki tüm örnekler ve açıklamalar güncellendi
- Metod isimlerinin değiştirilmesiyle ilgili referanslar güncellendi
- Örneklerde get yerine fetch kullanımı gösterildi

* Diğer İyileştirmeler

- Metod belgelerinde (doc comments) güncelleme ve iyileştirmeler yapıldı
- Belgelendirmelerde bölüm isimleri ve başlıklar tutarlı hale getirildi
- Türkçe ve İngilizce belgeler senkronize edildi